### PR TITLE
Fix missing addring/removering setup commands

### DIFF
--- a/src/main/java/com/elytrarace/commands/RaceCommand.java
+++ b/src/main/java/com/elytrarace/commands/RaceCommand.java
@@ -550,6 +550,8 @@ public class RaceCommand implements CommandExecutor, TabCompleter {
             sender.sendMessage("§e/er setup lobby §7- Set lobby");
             sender.sendMessage("§e/er setup start §7- Set start region");
             sender.sendMessage("§e/er setup finish §7- Set finish region");
+            sender.sendMessage("§e/er setup addring <name> §7- Add ring at your location");
+            sender.sendMessage("§e/er setup removering <name> §7- Remove a ring");
         }
         sender.sendMessage("§6§l╚════════════════════════════════════╝");
     }
@@ -603,6 +605,37 @@ public class RaceCommand implements CommandExecutor, TabCompleter {
                 regionManager.saveRegionFromSelection(minF, maxF, RegionManager.RegionType.FINISH);
                 sender.sendMessage(plugin.getConfigManager().getPrefix() + "§aFinish region saved.");
                 return true;
+            case "addring":
+                if (args.length < 3) {
+                    sender.sendMessage("§cUsage: /er setup addring <name>");
+                    return true;
+                }
+                String ringName = args[2];
+                plugin.getConfigManager().addRing(ringName, player.getLocation());
+                plugin.getRaceListener().refreshRingCache();
+                Location loc = player.getLocation();
+                sender.sendMessage(plugin.getConfigManager().getPrefix() +
+                    "§aRing '" + ringName + "' added at X: " +
+                    String.format("%.0f", loc.getX()) + " Y: " +
+                    String.format("%.0f", loc.getY()) + " Z: " +
+                    String.format("%.0f", loc.getZ()));
+                return true;
+            case "removering":
+                if (args.length < 3) {
+                    sender.sendMessage("§cUsage: /er setup removering <name>");
+                    return true;
+                }
+                String removeTarget = args[2];
+                if (!plugin.getConfigManager().getRingLocations().containsKey(removeTarget)) {
+                    sender.sendMessage(plugin.getConfigManager().getPrefix() +
+                        "§cRing not found: " + removeTarget);
+                    return true;
+                }
+                plugin.getConfigManager().removeRing(removeTarget);
+                plugin.getRaceListener().refreshRingCache();
+                sender.sendMessage(plugin.getConfigManager().getPrefix() +
+                    "§aRing '" + removeTarget + "' removed.");
+                return true;
             default:
                 showHelp(sender);
                 return true;
@@ -625,7 +658,7 @@ public class RaceCommand implements CommandExecutor, TabCompleter {
         } else if (args.length == 2) {
             switch (args[0].toLowerCase()) {
                 case "setup":
-                    return Arrays.asList("lobby", "start", "finish");
+                    return Arrays.asList("lobby", "start", "finish", "addring", "removering");
                 case "stats":
                 case "pb":
                 case "forcejoin":
@@ -634,6 +667,10 @@ public class RaceCommand implements CommandExecutor, TabCompleter {
                     return Collections.singletonList("rings");
                 case "platform":
                     return Arrays.asList("create", "remove");
+            }
+        } else if (args.length == 3) {
+            if (args[0].equalsIgnoreCase("setup") && args[1].equalsIgnoreCase("removering")) {
+                return new ArrayList<>(plugin.getConfigManager().getRingLocations().keySet());
             }
         }
         return Collections.emptyList();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ElytraRace
-version: 1.0.0
+version: 1.1.0
 main: com.elytrarace.ElytraRacePlugin
 api-version: 1.21
 author: YourName


### PR DESCRIPTION
## Summary

The `/er setup addring <name>` and `/er setup removering <name>` commands are documented in the README, COMMANDS.md, and config.yml comments, and the backend methods exist in `ConfigManager` (`addRing()`/`removeRing()`), but they were never wired up in `RaceCommand.handleSetup()`. Running either command in-game falls through to the default case and just shows the help menu.

This PR integrates them:

- **`addring` case** in `handleSetup()` — saves the player's current location as a ring via `ConfigManager.addRing()`, refreshes the ring cache, and confirms with coordinates
- **`removering` case** in `handleSetup()` — validates the ring exists, removes it via `ConfigManager.removeRing()`, refreshes the cache, and confirms
- **Tab completion** updated to include `addring` and `removering` under `/er setup`, plus ring name completion for `removering`
- **Help text** updated to list both commands in the admin section
- **plugin.yml version** bumped from `1.0.0` to `1.1.0` to match the rest of the project (README, config.yml, COMMANDS.md all reference v1.1.0)

## Test plan

- [ ] `/er setup addring ring1` — stand at a location, run command, verify ring saved to config and shows in `/er listrings`
- [ ] `/er setup addring` (no name) — verify usage message appears
- [ ] `/er setup removering ring1` — verify ring removed from config and `/er listrings`
- [ ] `/er setup removering nonexistent` — verify "Ring not found" error
- [ ] `/er setup removering` (no name) — verify usage message appears
- [ ] Tab complete `/er setup ` — verify `addring` and `removering` appear
- [ ] Tab complete `/er setup removering ` — verify existing ring names appear
- [ ] `/er` help menu — verify both commands listed under Admin Commands